### PR TITLE
Initial support for DB table prefixes.

### DIFF
--- a/tests/Mysql/MigrateDumpTest.php
+++ b/tests/Mysql/MigrateDumpTest.php
@@ -16,11 +16,11 @@ class MigrateDumpTest extends TestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertStringContainsString('CREATE TABLE `test_ms`', $result_sql);
-        $this->assertStringContainsString('INSERT INTO `migrations`', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE [\`\"]{$this->dbPrefix}test_ms[\`\"]/", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO [\`\"]{$this->dbPrefix}migrations[\`\"]/", $result_sql);
         $this->assertStringNotContainsString(' AUTO_INCREMENT=', $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 
     public function test_trimUnderscoresFromForeign()
@@ -50,17 +50,17 @@ class MigrateDumpTest extends TestCase
     public function test_reorderMigrationRows()
     {
         $output = [
-            "INSERT INTO migrations VALUES (1,'0001_01_01_000001_one',1);",
-            "INSERT INTO migrations VALUES (2,'0001_01_01_000003_three',2);",
-            "INSERT INTO migrations VALUES (3,'0001_01_01_000002_two',3);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (1,'0001_01_01_000001_one',1);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (2,'0001_01_01_000003_three',2);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (3,'0001_01_01_000002_two',3);",
         ];
         $reordered = array_values(
             MigrateDumpCommand::reorderMigrationRows($output)
         );
         $this->assertEquals([
-            "INSERT INTO migrations VALUES (1,'0001_01_01_000001_one',0);",
-            "INSERT INTO migrations VALUES (2,'0001_01_01_000002_two',0);",
-            "INSERT INTO migrations VALUES (3,'0001_01_01_000003_three',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (1,'0001_01_01_000001_one',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (2,'0001_01_01_000002_two',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (3,'0001_01_01_000003_three',0);",
         ], $reordered);
     }
 }

--- a/tests/Mysql/MigrateLoadTest.php
+++ b/tests/Mysql/MigrateLoadTest.php
@@ -26,12 +26,12 @@ class MigrateLoadTest extends TestCase
 
         $this->assertEquals(0, \DB::table('test_ms')->count());
 
-        $table_name = \DB::table('information_schema.tables')
+        $table_name = \DB::table(\DB::raw('information_schema.tables'))
             ->where('table_schema', \DB::getDatabaseName())
-            ->whereNotIn('table_name', ['migrations'])
+            ->whereNotIn('table_name', ["{$this->dbPrefix}migrations"])
             ->value('table_name');
 
-        $this->assertEquals('test_ms', $table_name);
+        $this->assertEquals("{$this->dbPrefix}test_ms", $table_name);
     }
 
     // TODO: Test no-drop and prompt-when-production.

--- a/tests/Postgresql/MigrateDumpTest.php
+++ b/tests/Postgresql/MigrateDumpTest.php
@@ -17,9 +17,9 @@ class MigrateDumpTest extends TestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertRegExp('/CREATE TABLE (public\.)?test_ms /', $result_sql);
-        $this->assertRegExp('/INSERT INTO (public\.)?migrations /', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE (public\.)?{$this->dbPrefix}test_ms /", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO (public\.)?{$this->dbPrefix}migrations /", $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 }

--- a/tests/Postgresql/MigrateLoadTest.php
+++ b/tests/Postgresql/MigrateLoadTest.php
@@ -27,14 +27,14 @@ class MigrateLoadTest extends TestCase
 
         $this->assertEquals(0, \DB::table('test_ms')->count());
 
-        $table_name = \DB::table('information_schema.tables')
+        $table_name = \DB::table(\DB::raw('information_schema.tables'))
             ->where('table_catalog', \DB::getDatabaseName())
             ->where('table_schema', 'public')
-            ->whereNotIn('table_name', ['migrations'])
+            ->whereNotIn('table_name', ["{$this->dbPrefix}migrations"])
             ->where('table_name', 'NOT LIKE', 'pg_%')
             ->value('table_name');
 
-        $this->assertEquals('test_ms', $table_name);
+        $this->assertEquals("{$this->dbPrefix}test_ms", $table_name);
     }
 
     // TODO: Test no-drop and prompt-when-production.

--- a/tests/Sqlite/MigrateDumpTest.php
+++ b/tests/Sqlite/MigrateDumpTest.php
@@ -13,9 +13,9 @@ class MigrateDumpTest extends SqliteTestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertRegExp('/CREATE TABLE( IF NOT EXISTS)? "test_ms" /', $result_sql);
-        $this->assertRegExp('/INSERT INTO "?migrations"? /', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE( IF NOT EXISTS)? \"{$this->dbPrefix}test_ms\" /", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO \"?{$this->dbPrefix}migrations\"? /", $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected $dbDefault = 'mysql';
+    protected $dbPrefix = 'omp_';
     protected $schemaSqlDirectory;
     protected $schemaSqlPath;
 
@@ -34,6 +35,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('database.default', $this->dbDefault);
+        $oldDbConnConfig = $app['config']->get('database.connections.' . $this->dbDefault) ?? [];
+        $app['config']->set(
+            'database.connections.' . $this->dbDefault,
+            ['prefix' => $this->dbPrefix] + $oldDbConnConfig
+        );
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
### Manual test steps
1. checkout locally
2. composer require from local copy
3. set non-black `prefix` in your `config/database.php` connection
4. `php artisan migrate`
5. verify dumped schema has table prefixes intact, including migrations table
6. `php artisan migrate:load`
7. verify succeeds