### PR TITLE
Fixed migration-snapshot.data config not opting into dumping data aft…

### DIFF
--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -78,9 +78,8 @@ final class MigrateDumpCommand extends Command
 
                 exit($exit_code);
             }
+            $this->info('Dumped Data');
         }
-
-        $this->info('Dumped Data');
 
         $after_dump = config('migration-snapshot.after-dump');
         if ($after_dump) {
@@ -321,7 +320,8 @@ final class MigrateDumpCommand extends Command
         exec(
             static::pgsqlCommandPrefix($db_config)
             . ' --table=' . escapeshellarg(($db_config['prefix'] ?? '') . 'migrations')
-            . ' --data-only --inserts',
+            . ' --data-only'
+            . ' --inserts',
             $output,
             $exit_code
         );

--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -17,7 +17,8 @@ class MigrateFinishedHandler
             && env('MIGRATION_SNAPSHOT', true)
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)
         ) {
-            $options = MigrateStartingHandler::inputToArtisanOptions($event->input);
+            $options = MigrateStartingHandler::inputToArtisanOptions($event->input)
+                + ['--include-data' => config('migration-snapshot.data') ?? false];
             $database = $options['--database'] ?? env('DB_CONNECTION');
             $db_driver = \DB::connection($database)->getDriverName();
             if (! in_array($db_driver, MigrateDumpCommand::SUPPORTED_DB_DRIVERS, true)) {


### PR DESCRIPTION
…er `artisan migrate`.

### Manual test steps
1. checkout locally
2. composer require against local checkout within other Laravel project
3. set `data` to `true` in `config/migration-snapshot.php` of requiring Laravel project
4. `php artisan migrate`
5. verify data dumped to `database/migrations/sql/data.sql`