### PR TITLE
Use pgdump custom format for data dumps with PostgreSQL to workaround…

### DIFF
--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -360,6 +360,7 @@ final class MigrateDumpCommand extends Command
         passthru(
             static::pgsqlCommandPrefix($db_config)
             . ' --file=' . escapeshellarg($data_sql_path)
+            . ' --format=c' // Needed to workaround dumping data separately.
             . ' --exclude-table=' . escapeshellarg($db_config['database'] . '.' . ($db_config['prefix'] ?? '') . 'migrations')
             . ' --data-only',
             $exit_code

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -62,18 +62,21 @@ final class MigrateDumpCommand extends Command
 
         $this->info('Dumped schema');
 
-        $data_sql_path = null;
+        $data_path = null;
         if ($this->option('include-data')) {
             $this->info('Starting Data Dump');
 
-            $data_sql_path = database_path() . self::DATA_SQL_PATH_SUFFIX;
+            $data_path = database_path() . self::DATA_SQL_PATH_SUFFIX;
+            if ('pgsql' === $db_config['driver']) {
+                $data_path = preg_replace('/\.sql$/', '.pgdump', $data_path);
+            }
 
             $method = $db_config['driver'] . 'DataDump';
-            $exit_code = self::{$method}($db_config, $data_sql_path);
+            $exit_code = self::{$method}($db_config, $data_path);
 
             if (0 !== $exit_code) {
-                if (file_exists($data_sql_path)) {
-                    unlink($data_sql_path);
+                if (file_exists($data_path)) {
+                    unlink($data_path);
                 }
 
                 exit($exit_code);
@@ -83,7 +86,7 @@ final class MigrateDumpCommand extends Command
 
         $after_dump = config('migration-snapshot.after-dump');
         if ($after_dump) {
-            $after_dump($schema_sql_path, $data_sql_path);
+            $after_dump($schema_sql_path, $data_path);
             $this->info('Ran After-dump');
         }
     }

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -4,6 +4,7 @@ namespace AlwaysOpen\MigrationSnapshot\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -72,6 +73,9 @@ final class MigrateLoadCommand extends Command
         $this->info('Loaded schema');
 
         $data_path = database_path() . MigrateDumpCommand::DATA_SQL_PATH_SUFFIX;
+        if ('pgsql' === $db_config['driver']) {
+            $data_path = preg_replace('/\.sql$/', '.pgdump', $data_path);
+        }
         if (file_exists($data_path)) {
             $this->info('Loading default data...');
 
@@ -147,30 +151,37 @@ final class MigrateLoadCommand extends Command
         // CONSIDER: Capturing Stderr and outputting with `$this->error()`.
 
         // CONSIDER: Making input file an option which can override default.
+        $needsPgRestore = Str::endsWith($path, '.pgdump');
+
+        // Pg_restore needed to workaround dumping data separately from DDL
+        // because FKs are present, so `--disable-triggers` is necessary. An
+        // added benefit is smaller file size, at the cost of some readability.
+        // CONSIDER: Optionally dumping data as txt and wrapping in
+        // `SET session_replication_role =…`, yet requires extra permissions.
         $command = 'PGPASSWORD=' . escapeshellarg($db_config['password'])
-            . ' psql --file=' . escapeshellarg($path)
+            . ($needsPgRestore ? ' pg_restore --disable-triggers' : ' psql')
             . ' --host=' . escapeshellarg($db_config['host'])
             . ' --port=' . escapeshellarg($db_config['port'] ?? 5432)
             . ' --username=' . escapeshellarg($db_config['username'])
             . ' --dbname=' . escapeshellarg($db_config['database']);
         switch($verbosity) {
             case OutputInterface::VERBOSITY_QUIET:
-                $command .= ' --quiet --output=/dev/null';
+                $command .= $needsPgRestore ? '' : ' --quiet --output=/dev/null';
                 break;
             case OutputInterface::VERBOSITY_NORMAL:
-                // By default psql outputs command results like "SET".
-                $command .= ' --output=/dev/null';
+                $command .= $needsPgRestore ? ' -v' : ' --output=/dev/null';
                 break;
             case OutputInterface::VERBOSITY_VERBOSE:
-                // No op.
+                $command .= $needsPgRestore ? ' -vv' : ''; // psql is verbose by default.
                 break;
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
-                $command .= ' --echo-errors';
+                $command .= $needsPgRestore ? ' -vvv' : ' --echo-errors';
                 break;
             case OutputInterface::VERBOSITY_DEBUG:
-                $command .= ' --echo-all';
+                $command .= $needsPgRestore ? ' -vvvv' : ' --echo-all';
                 break;
         }
+        $command .= ' ' . ($needsPgRestore ? '' : '--file=') . escapeshellarg($path);
 
         passthru($command, $exit_code);
 


### PR DESCRIPTION
… loading problem when FKs included.

### Manual test steps
1. checkout locally
2. composer require locally checked out copy in other Laravel project using PostgreSQL and FKs
3. `php artisan migrate:dump --include-data`
4. verify `database/migrations/sql/data.pgdump` file exists
5. `php artisan migrate:load`
6. verify that output contains `pg_restore: …` and data successfully restored into DB