### PR TITLE
Add after-load config option to aid post-loading preparation.

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -70,4 +70,17 @@ return [
     |
     */
     'after-dump' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | After Load
+    |--------------------------------------------------------------------------
+    |
+    | Run this closure after loading snapshot. Helps when one needs to refresh
+    | materialized views or otherwise prep a fresh DB.
+    |
+    | Must accept two arguments: `function ($schema_sql_path, $data_sql_path)`.
+    |
+    */
+    'after-load' => null,
 ];

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -29,8 +29,8 @@ final class MigrateLoadCommand extends Command
             return;
         }
 
-        $path = database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX;
-        if (! file_exists($path)) {
+        $schema_sql_path = database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX;
+        if (! file_exists($schema_sql_path)) {
             throw new InvalidArgumentException(
                 'Schema-migrations path not found, run `migrate:dump` first.'
             );
@@ -64,7 +64,7 @@ final class MigrateLoadCommand extends Command
         // CONSIDER: Accepting options for underlying restore utilities from CLI.
         // CONSIDER: Option to restore to console Stdout instead.
         $method = $db_config['driver'] . 'Load';
-        $exit_code = self::{$method}($path, $db_config, $this->getOutput()->getVerbosity());
+        $exit_code = self::{$method}($schema_sql_path, $db_config, $this->getOutput()->getVerbosity());
 
         if (0 !== $exit_code) {
             exit($exit_code); // CONSIDER: Returning instead.
@@ -86,6 +86,11 @@ final class MigrateLoadCommand extends Command
             }
 
             $this->info('Loaded default data successfully!');
+        }
+
+        if ($after_load = config('migration-snapshot.after-load')) {
+            $after_load($schema_sql_path, $data_path);
+            $this->info('Ran After-load');
         }
     }
 

--- a/tests/MigrateLoadAfterClosureTest.php
+++ b/tests/MigrateLoadAfterClosureTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace AlwaysOpen\MigrationSnapshot\Tests;
+
+class MigrateLoadAfterClosureTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set(
+            'migration-snapshot.after-load',
+            function ($schema_sql_path, $data_sql_path) {
+                throw new \RuntimeException("AfterLoadTest,{$schema_sql_path},{$data_sql_path}");
+            }
+        );
+    }
+
+    public function test_load_callsAfterLoadClosure()
+    {
+        $this->createTestTablesWithoutMigrate();
+        $result = \Artisan::call('migrate:dump');
+        $this->assertSame(0, $result);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("AfterLoadTest,");
+        \Artisan::call('migrate:load');
+    }
+}

--- a/tests/Postgresql/MigrateLoadTest.php
+++ b/tests/Postgresql/MigrateLoadTest.php
@@ -9,17 +9,6 @@ class MigrateLoadTest extends TestCase
 {
     protected $dbDefault = 'pgsql';
 
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-        $app['config']->set(
-            'migration-snapshot.after-load',
-            function ($schema_sql_path, $data_sql_path) {
-                throw new \RuntimeException("AfterLoadTest,{$schema_sql_path},{$data_sql_path}");
-            }
-        );
-    }
-
     public function test_handle()
     {
         // Make the dump file.
@@ -49,14 +38,4 @@ class MigrateLoadTest extends TestCase
     }
 
     // TODO: Test no-drop and prompt-when-production.
-
-    public function test_load_callsAfterLoadClosure()
-    {
-        $this->createTestTablesWithoutMigrate();
-        $result = \Artisan::call('migrate:dump');
-        $this->assertSame(0, $result);
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("AfterLoadTest,");
-        \Artisan::call('migrate:load');
-    }
 }

--- a/tests/Postgresql/MigrateLoadTest.php
+++ b/tests/Postgresql/MigrateLoadTest.php
@@ -9,6 +9,17 @@ class MigrateLoadTest extends TestCase
 {
     protected $dbDefault = 'pgsql';
 
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set(
+            'migration-snapshot.after-load',
+            function ($schema_sql_path, $data_sql_path) {
+                throw new \RuntimeException("AfterLoadTest,{$schema_sql_path},{$data_sql_path}");
+            }
+        );
+    }
+
     public function test_handle()
     {
         // Make the dump file.
@@ -38,4 +49,14 @@ class MigrateLoadTest extends TestCase
     }
 
     // TODO: Test no-drop and prompt-when-production.
+
+    public function test_load_callsAfterLoadClosure()
+    {
+        $this->createTestTablesWithoutMigrate();
+        $result = \Artisan::call('migrate:dump');
+        $this->assertSame(0, $result);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("AfterLoadTest,");
+        \Artisan::call('migrate:load');
+    }
 }


### PR DESCRIPTION
### Manual test steps
1. checkout locally
2. composer require local copy in other Laravel project
3. add `after-load` closure to its `config/migration-snapshot.php`
4. run `php artisan migrate:load`
5. verify `after-load` closure has run and console reads "Ran After-load"