### PR TITLE
Separate env var override into two and move to config.

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -3,6 +3,24 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Whether to automatically dump after running `migrate`.
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'dump' => env('MIGRATION_SNAPSHOT_DUMP', env('MIGRATION_SNAPSHOT', true)),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Whether to automatically load when running `migrate` into an empty DB.
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'load' => env('MIGRATION_SNAPSHOT_LOAD', env('MIGRATION_SNAPSHOT', true)),
+
+    /*
+    |--------------------------------------------------------------------------
     | Which environments to implicitly dump/load
     |--------------------------------------------------------------------------
     |

--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -14,7 +14,7 @@ class MigrateFinishedHandler
             // CONSIDER: Also `migrate:fresh`.
             in_array($event->command, ['migrate', 'migrate:rollback'], true)
             && ! $event->input->hasParameterOption(['--help', '--pretend', '-V', '--version'])
-            && env('MIGRATION_SNAPSHOT', true)
+            && config('migration-snapshot.dump', true)
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)
         ) {
             $options = MigrateStartingHandler::inputToArtisanOptions($event->input)

--- a/src/Handlers/MigrateStartingHandler.php
+++ b/src/Handlers/MigrateStartingHandler.php
@@ -55,7 +55,7 @@ class MigrateStartingHandler
             // Avoid knowingly starting migrate which will fail.
             && self::inputValidateWorkaround($event->input)
             && ! $event->input->hasParameterOption(['--help', '--pretend', '-V', '--version'])
-            && env('MIGRATION_SNAPSHOT', true) // CONSIDER: Config option.
+            && config('migration-snapshot.load', true)
             // Never implicitly load fresh (from file) in production since it
             // would need to drop first, and that would be destructive.
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)


### PR DESCRIPTION
### Manual test steps
1. checkout locally
2. composer require local checkout into other Laravel project
3. `MIGRATION_SNAPSHOT_DUMP=0   php artisan migrate`
4. verify the schema is not dumped to `database/migrations/sql/schema.sql`, though pre-existing file may be left unchanged
5. `php artisan migrate:dump`
6. drop all tables and views from DB
7. `MIGRATION_SNAPSHOT_LOAD=0   php artisan migrate`
8. verify individual migrations were run, not loaded from earlier dump