### PR TITLE
Accept after-dump and after-load as array for Artisan call.

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -80,11 +80,12 @@ return [
     | After Dump
     |--------------------------------------------------------------------------
     |
-    | Run this closure after dumping snapshot. Helps when output may vary by
-    | environment in unimportant ways which would just pollute the SCM history
-    | with noisy changes.
+    | Run this Artisan command or closure after dumping snapshot. Helps when
+    | output may vary by environment in unimportant ways which would just
+    | pollute the SCM history with noisy changes.
     |
-    | Must accept two arguments: `function ($schema_sql_path, $data_sql_path)`.
+    | If an array values must align with arguments to `Artisan::call()`.
+    | If a closure it must be: `function ($schema_sql_path, $data_sql_path)`.
     |
     */
     'after-dump' => null,
@@ -94,10 +95,11 @@ return [
     | After Load
     |--------------------------------------------------------------------------
     |
-    | Run this closure after loading snapshot. Helps when one needs to refresh
-    | materialized views or otherwise prep a fresh DB.
+    | Run this Artisan command or closure after loading snapshot. Helps when
+    | one needs to refresh materialized views or otherwise prep a fresh DB.
     |
-    | Must accept two arguments: `function ($schema_sql_path, $data_sql_path)`.
+    | If an array values must align with arguments to `Artisan::call()`.
+    | If a closure it must be: `function ($schema_sql_path, $data_sql_path)`.
     |
     */
     'after-load' => null,

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -3,6 +3,7 @@
 namespace AlwaysOpen\MigrationSnapshot\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 
 final class MigrateDumpCommand extends Command
@@ -84,9 +85,14 @@ final class MigrateDumpCommand extends Command
             $this->info('Dumped Data');
         }
 
-        $after_dump = config('migration-snapshot.after-dump');
-        if ($after_dump) {
-            $after_dump($schema_sql_path, $data_path);
+        if ($after_dump = config('migration-snapshot.after-dump')) {
+            if (is_string($after_dump)) {
+                Artisan::call($after_dump);
+            } elseif (is_array($after_dump)) {
+                Artisan::call($after_dump[0], $after_dump[1] ?? [], $after_dump[2] ?? null);
+            } else {
+                $after_dump($schema_sql_path, $data_path);
+            }
             $this->info('Ran After-dump');
         }
     }

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -3,6 +3,7 @@
 namespace AlwaysOpen\MigrationSnapshot\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -89,7 +90,13 @@ final class MigrateLoadCommand extends Command
         }
 
         if ($after_load = config('migration-snapshot.after-load')) {
-            $after_load($schema_sql_path, $data_path);
+            if (is_string($after_load)) {
+                Artisan::call($after_load);
+            } elseif (is_array($after_load)) {
+                Artisan::call($after_load[0], $after_load[1] ?? [], $after_load[2] ?? null);
+            } else {
+                $after_load($schema_sql_path, $data_path);
+            }
             $this->info('Ran After-load');
         }
     }


### PR DESCRIPTION
So one can use `config:cache` with after-load and after-dump

### Manual test steps
1. checkout locally
2. composer require local checkout in other Laravel project
3. change `after-load` to an array with values that align with `Artisan::call()` arguments
4. `php artisan migrate:dump`
5. verify after-load ran the given Artisan command
6. `php artisan config:cache`
7. verify that "Your configuration files are not serializable" error does not appear