### PR TITLE
Added migrate:fresh to array of commands after which migrate:dump will automatically run

### DIFF
--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -11,8 +11,7 @@ class MigrateFinishedHandler
     public function handle(CommandFinished $event)
     {
         if (
-            // CONSIDER: Also `migrate:fresh`.
-            in_array($event->command, ['migrate', 'migrate:rollback'], true)
+            in_array($event->command, ['migrate', 'migrate:fresh', 'migrate:rollback'], true)
             && ! $event->input->hasParameterOption(['--help', '--pretend', '-V', '--version'])
             && config('migration-snapshot.dump', true)
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)

--- a/tests/MigrateHookTest.php
+++ b/tests/MigrateHookTest.php
@@ -28,6 +28,24 @@ class MigrateHookTest extends TestCase
         $this->assertStringContainsString('Dumped schema', $output_string);
     }
 
+    public function test_handle_dumpsOnFresh()
+    {
+        $this->createTestTablesWithoutMigrate();
+
+        $output = new BufferedOutput();
+        $result = \Artisan::call('migrate:fresh',
+            [
+                '--path' => realpath(__DIR__ . '/migrations/setup'),
+                '--realpath' => true,
+            ],
+            $output
+        );
+        $this->assertEquals(0, $result);
+
+        $output_string = $output->fetch();
+        $this->assertStringContainsString('Dumped schema', $output_string);
+    }
+
     public function test_handle_dumpsOnRollback()
     {
         $this->createTestTablesWithoutMigrate();


### PR DESCRIPTION
Added `migrate:fresh` to the list of commands after which the `migrate:dump` command will automatically run.