### PR TITLE
Update both commands to read/write database driver-specific files

### DIFF
--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -8,10 +8,9 @@ use Illuminate\Support\Facades\DB;
 
 final class MigrateDumpCommand extends Command
 {
-    public const SCHEMA_SQL_PATH_SUFFIX = '/migrations/sql/schema.sql';
-    public const DATA_SQL_PATH_SUFFIX = '/migrations/sql/data.sql';
-
     public const SUPPORTED_DB_DRIVERS = ['mysql', 'pgsql', 'sqlite'];
+    protected const SCHEMA_SQL_PATH_SUFFIX = 'migrations/sql/schema.';
+    protected const DATA_SQL_PATH_SUFFIX = 'migrations/sql/data.';
 
     protected $signature = 'migrate:dump
         {--database= : The database connection to use}
@@ -28,7 +27,7 @@ final class MigrateDumpCommand extends Command
 
         // CONSIDER: Ending with ".mysql" or "-mysql.sql" unless in
         // compatibility mode.
-        $schema_sql_path = database_path() . self::SCHEMA_SQL_PATH_SUFFIX;
+        $schema_sql_path = self::getSchemaSqlPath($db_config['driver']);
         $schema_sql_directory = dirname($schema_sql_path);
         if (! file_exists($schema_sql_directory)) {
             mkdir($schema_sql_directory, 0755);
@@ -36,7 +35,7 @@ final class MigrateDumpCommand extends Command
 
         if (! in_array($db_config['driver'], self::SUPPORTED_DB_DRIVERS, true)) {
             throw new \InvalidArgumentException(
-                'Unsupported DB driver ' . var_export($db_config['driver'], 1)
+                'Unsupported database driver ' . var_export($db_config['driver'], 1)
             );
         }
 
@@ -59,13 +58,13 @@ final class MigrateDumpCommand extends Command
             exit($exit_code); // CONSIDER: Returning instead.
         }
 
-        $this->info('Dumped schema');
+        $this->info('Dumped ' . $db_config['driver'] . ' schema');
 
         $data_path = null;
         if ($this->option('include-data')) {
             $this->info('Starting Data Dump');
 
-            $data_path = database_path() . self::DATA_SQL_PATH_SUFFIX;
+            $data_path = self::getDataSqlPath($db_config['driver']);
             if ('pgsql' === $db_config['driver']) {
                 $data_path = preg_replace('/\.sql$/', '.pgdump', $data_path);
             }
@@ -130,6 +129,16 @@ final class MigrateDumpCommand extends Command
         }
 
         return $output;
+    }
+
+    public static function getSchemaSqlPath(string $driver) : string
+    {
+        return database_path(self::SCHEMA_SQL_PATH_SUFFIX . $driver . '.sql');
+    }
+
+    public static function getDataSqlPath(string $driver) : string
+    {
+        return database_path(self::DATA_SQL_PATH_SUFFIX . $driver . '.sql');
     }
 
     /**

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -22,8 +22,6 @@ final class MigrateDumpCommand extends Command
 
     public function handle()
     {
-        $exit_code = null;
-
         $database = $this->option('database') ?: DB::getDefaultConnection();
         DB::setDefaultConnection($database);
         $db_config = DB::getConfig();

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -142,14 +142,15 @@ final class MigrateDumpCommand extends Command
      */
     private static function mysqlSchemaDump(array $db_config, string $schema_sql_path) : int
     {
-        // TODO: Suppress warning about insecure password.
         // CONSIDER: Intercepting stdout and stderr and converting to colorized
         // console output with `$this->info` and `->error`.
         passthru(
-            static::mysqlCommandPrefix($db_config)
+            'bash -c "'
+            . static::mysqlCommandPrefix($db_config)
             . ' --result-file=' . escapeshellarg($schema_sql_path)
             . ' --no-data'
-            . ' --routines',
+            . ' --routines'
+            . ' 2> >(grep -v \'Using a password on the command line interface can be insecure.\')"',
             $exit_code
         );
 
@@ -170,13 +171,15 @@ final class MigrateDumpCommand extends Command
 
         // Include migration rows to avoid unnecessary reruns conflicting.
         exec(
-            static::mysqlCommandPrefix($db_config)
+            'bash -c "'
+                . static::mysqlCommandPrefix($db_config)
                 . ' ' . ($db_config['prefix'] ?? '') . 'migrations'
                 . ' --no-create-info'
                 . ' --skip-extended-insert'
                 . ' --skip-routines'
                 . ' --single-transaction'
-                . ' --compact',
+                . ' --compact'
+            . ' 2> >(grep -v \'Using a password on the command line interface can be insecure.\')"',
             $output,
             $exit_code
         );
@@ -207,11 +210,13 @@ final class MigrateDumpCommand extends Command
     private static function mysqlDataDump(array $db_config, string $data_sql_path) : int
     {
         passthru(
-            static::mysqlCommandPrefix($db_config)
+            'bash -c "'
+            . static::mysqlCommandPrefix($db_config)
             . ' --result-file=' . escapeshellarg($data_sql_path)
             . ' --no-create-info --skip-routines --skip-triggers'
             . ' --ignore-table=' . escapeshellarg($db_config['database'] . '.' . ($db_config['prefix'] ?? '') . 'migrations')
-            . ' --single-transaction', // Avoid disruptive locks.
+            . ' --single-transaction' // Avoid disruptive locks.
+            . ' 2> >(grep -v \'Using a password on the command line interface can be insecure.\')"',
             $exit_code
         );
 

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -25,8 +25,6 @@ final class MigrateDumpCommand extends Command
         DB::setDefaultConnection($database);
         $db_config = DB::getConfig();
 
-        // CONSIDER: Ending with ".mysql" or "-mysql.sql" unless in
-        // compatibility mode.
         $schema_sql_path = self::getSchemaSqlPath($db_config['driver']);
         $schema_sql_directory = dirname($schema_sql_path);
         if (! file_exists($schema_sql_directory)) {

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -41,7 +41,7 @@ final class MigrateLoadCommand extends Command
         $schema_sql_path = MigrateDumpCommand::getSchemaSqlPath($db_config['driver']);
         if (! file_exists($schema_sql_path)) {
             throw new InvalidArgumentException(
-                'No schema dump found for the current database driver. Run `migrate:dump --database ' . $db_config['driver'] . '` before running this command.'
+                'No schema dump found for the current database driver. Run `migrate:dump --database=' . $database . '` before running this command.'
             );
         }
 
@@ -116,13 +116,15 @@ final class MigrateLoadCommand extends Command
         // CONSIDER: Making input file an option which can override default.
         // CONSIDER: Avoiding shell specifics like `cat` and piping using
         // `file_get_contents` or similar.
-        $command = 'cat ' . escapeshellarg($path)
+        $command = 'bash -c "'
+            . 'cat ' . escapeshellarg($path)
             . ' | mysql --no-beep'
             . ' --host=' . escapeshellarg($db_config['host'])
             . ' --port=' . escapeshellarg($db_config['port'] ?? 3306)
             . ' --user=' . escapeshellarg($db_config['username'])
             . ' --password=' . escapeshellarg($db_config['password'])
-            . ' --database=' . escapeshellarg($db_config['database']);
+            . ' --database=' . escapeshellarg($db_config['database'])
+            . ' 2> >(grep -v \'Using a password on the command line interface can be insecure.\')"';
         switch($verbosity) {
             case OutputInterface::VERBOSITY_QUIET:
                 $command .= ' -q';

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -20,21 +20,12 @@ final class MigrateLoadCommand extends Command
 
     public function handle()
     {
-        $exit_code = null;
-
         if (
             ! $this->option('force')
             && app()->environment('production')
-            && ! $this->confirm('Are you sure you want to load the DB schema from a file?')
+            && ! $this->confirm('Are you sure you want to load the database schema from a file?')
         ) {
             return;
-        }
-
-        $schema_sql_path = database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX;
-        if (! file_exists($schema_sql_path)) {
-            throw new InvalidArgumentException(
-                'Schema-migrations path not found, run `migrate:dump` first.'
-            );
         }
 
         $database = $this->option('database') ?: DB::getDefaultConnection();
@@ -43,7 +34,14 @@ final class MigrateLoadCommand extends Command
 
         if (! in_array($db_config['driver'], MigrateDumpCommand::SUPPORTED_DB_DRIVERS, true)) {
             throw new InvalidArgumentException(
-                'Unsupported DB driver ' . var_export($db_config['driver'], 1)
+                'Unsupported database driver ' . var_export($db_config['driver'], 1)
+            );
+        }
+
+        $schema_sql_path = MigrateDumpCommand::getSchemaSqlPath($db_config['driver']);
+        if (! file_exists($schema_sql_path)) {
+            throw new InvalidArgumentException(
+                'No schema dump found for the current database driver. Run `migrate:dump --database ' . $db_config['driver'] . '` before running this command.'
             );
         }
 
@@ -71,9 +69,9 @@ final class MigrateLoadCommand extends Command
             exit($exit_code); // CONSIDER: Returning instead.
         }
 
-        $this->info('Loaded schema');
+        $this->info('Loaded ' . $db_config['driver'] . ' schema');
 
-        $data_path = database_path() . MigrateDumpCommand::DATA_SQL_PATH_SUFFIX;
+        $data_path = MigrateDumpCommand::getDataSqlPath($db_config['driver']);
         if ('pgsql' === $db_config['driver']) {
             $data_path = preg_replace('/\.sql$/', '.pgdump', $data_path);
         }

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -3,12 +3,17 @@
 
 namespace AlwaysOpen\MigrationSnapshot;
 
+use AlwaysOpen\MigrationSnapshot\Handlers\MigrateFinishedHandler;
+use AlwaysOpen\MigrationSnapshot\Handlers\MigrateStartingHandler;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+
 final class EventServiceProvider extends \Illuminate\Foundation\Support\Providers\EventServiceProvider
 {
     protected $listen = [
         // CONSIDER: Only registering these when Laravel version doesn't have
         // more specific hooks.
-        'Illuminate\Console\Events\CommandFinished' => ['AlwaysOpen\MigrationSnapshot\Handlers\MigrateFinishedHandler'],
-        'Illuminate\Console\Events\CommandStarting' => ['AlwaysOpen\MigrationSnapshot\Handlers\MigrateStartingHandler'],
+        CommandFinished::class => [MigrateFinishedHandler::class],
+        CommandStarting::class => [MigrateStartingHandler::class],
     ];
 }

--- a/src/Handlers/MigrateStartingHandler.php
+++ b/src/Handlers/MigrateStartingHandler.php
@@ -59,8 +59,6 @@ class MigrateStartingHandler
             // Never implicitly load fresh (from file) in production since it
             // would need to drop first, and that would be destructive.
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)
-            // No point in implicitly loading when it's not present.
-            && file_exists(database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX)
         ) {
             // Must pass along options or it may use wrong DB or have
             // inconsistent output.
@@ -68,6 +66,12 @@ class MigrateStartingHandler
             $database = $options['--database'] ?? \DB::getConfig('name');
             $db_driver = \DB::connection($database)->getDriverName();
             if (! in_array($db_driver, MigrateDumpCommand::SUPPORTED_DB_DRIVERS, true)) {
+                // CONSIDER: Logging or emitting console warning.
+                return;
+            }
+
+            // No point in continuing to load when it's not present.
+            if (!file_exists(MigrateDumpCommand::getSchemaSqlPath($db_driver))) {
                 // CONSIDER: Logging or emitting console warning.
                 return;
             }

--- a/tests/MigrateDumpTest.php
+++ b/tests/MigrateDumpTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateDumpTest extends TestCase
@@ -30,9 +29,7 @@ class MigrateDumpTest extends TestCase
         $result = \Artisan::call('migrate:dump');
         $this->assertEquals(0, $result);
 
-        $schema_sql = file_get_contents(
-            database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX
-        );
+        $schema_sql = file_get_contents($this->schemaSqlPath);
         $this->assertStringNotContainsString('/*', $schema_sql);
     }
 }

--- a/tests/MigrateHookTest.php
+++ b/tests/MigrateHookTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace AlwaysOpen\MigrationSnapshot\Tests\Mysql;
 
 use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
@@ -24,8 +23,8 @@ class MigrateHookTest extends TestCase
         $this->assertEquals(0, $result);
 
         $output_string = $output->fetch();
-        $this->assertStringContainsString('Loaded schema', $output_string);
-        $this->assertStringContainsString('Dumped schema', $output_string);
+        $this->assertStringContainsString('Loaded ' . $this->dbDefault . ' schema', $output_string);
+        $this->assertStringContainsString('Dumped ' . $this->dbDefault . ' schema', $output_string);
     }
 
     public function test_handle_dumpsOnRollback()
@@ -44,7 +43,7 @@ class MigrateHookTest extends TestCase
         $this->assertEquals(0, $result);
 
         $output_string = $output->fetch();
-        $this->assertStringContainsString('Dumped schema', $output_string);
+        $this->assertStringContainsString('Dumped ' . $this->dbDefault . ' schema', $output_string);
     }
 
     public function test_handle_doesNotLoadWhenDbHasMigrated()
@@ -61,7 +60,7 @@ class MigrateHookTest extends TestCase
         $this->assertEquals(0, $result);
 
         $output_string = $output->fetch();
-        $this->assertStringNotContainsString('Loaded schema', $output_string);
+        $this->assertStringNotContainsString('Loaded ' . $this->dbDefault . ' schema', $output_string);
 
         $this->assertEquals(1, \DB::table('test_ms')->count());
     }

--- a/tests/MigrateHookTest.php
+++ b/tests/MigrateHookTest.php
@@ -42,7 +42,7 @@ class MigrateHookTest extends TestCase
         $this->assertEquals(0, $result);
 
         $output_string = $output->fetch();
-        $this->assertStringContainsString('Dumped schema', $output_string);
+        $this->assertStringContainsString('Dumped ' . $this->dbDefault . ' schema', $output_string);
     }
 
     public function test_handle_dumpsOnRollback()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace AlwaysOpen\MigrationSnapshot\Tests;
 
 
 use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\ServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -17,9 +18,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        $this->schemaSqlPath = realpath(
-                __DIR__ . '/../vendor/orchestra/testbench-core/laravel/database'
-            ) . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX;
+        $this->schemaSqlPath = MigrateDumpCommand::getSchemaSqlPath(
+            $this->app['config']->get('database.connections.' . $this->dbDefault . '.driver')
+        );
         $this->schemaSqlDirectory = dirname($this->schemaSqlPath);
 
         // Not leaving to tearDown since it can be useful to see result after
@@ -44,7 +45,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getPackageProviders($app)
     {
-        return ['\AlwaysOpen\MigrationSnapshot\ServiceProvider'];
+        return [ServiceProvider::class];
     }
 
     protected function createTestTablesWithoutMigrate() : void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,7 +39,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $oldDbConnConfig = $app['config']->get('database.connections.' . $this->dbDefault) ?? [];
         $app['config']->set(
             'database.connections.' . $this->dbDefault,
-            ['prefix' => $this->dbPrefix] + $oldDbConnConfig
+            ['username' => 'root', 'prefix' => $this->dbPrefix] + $oldDbConnConfig
         );
     }
 


### PR DESCRIPTION
There was a consideration in the dump command that mentioned using driver-specific filenames. I really like that idea since I am using two different databases currently. Doing this ensures that the load command can succeed if the schema file exists because it should have the correct syntax to do so.

- Updated the `schema.sql` and `data.sql` filenames to be driver specific (e.g. `schema.mysql.sql` or `schema.pgsql.sql`)