### PR TITLE
Fixed `migrations_id_seq` missing from dumps

### DIFF
--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -360,7 +360,8 @@ final class MigrateDumpCommand extends Command
         $output = array_filter(
             $output,
             function ($line) {
-                return 0 === preg_match('/^\s*(--|SELECT\s|SET\s)/iu', $line)
+                // Keep SELECT for `setval` so future migration IDs don't conflict.
+                return 0 === preg_match('/^\s*(--|SET\s)/iu', $line)
                     && 0 < mb_strlen($line);
             }
         );

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -108,6 +108,9 @@ final class MigrateDumpCommand extends Command
         if (config('migration-snapshot.reorder')) {
             $reordered = [];
             foreach ($output as $line) {
+                if (str_starts_with($line, 'SELECT ')) {
+                    continue; // Disregard `setval` and pgcatalog lines.
+                }
                 // Extract parts of "INSERT ... VALUES ([id],'[ver]',[batch])
                 // where version begins with "YYYY_MM_DD_HHMMSS".
                 $occurrences = preg_match(


### PR DESCRIPTION
Stop filtering out SELECT so that `setval` is kept and later migration IDs won't conflict.